### PR TITLE
Skip e2e when missing API key

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   e2e-test:
+    if: ${{ secrets.GEMINI_API_KEY != '' }}
     name: E2E Test - ${{ matrix.sandbox }}
     runs-on: ubuntu-latest
     strategy:

--- a/docs/integration-tests.md
+++ b/docs/integration-tests.md
@@ -132,7 +132,7 @@ This structure makes it easy to locate the artifacts for a specific test run, fi
 
 ## Continuous integration
 
-To ensure the integration tests are always run, a GitHub Actions workflow is defined in `.github/workflows/e2e.yml`. This workflow automatically runs the integration tests on every pull request and push to the `main` branch.
+To ensure the integration tests are always run, a GitHub Actions workflow is defined in `.github/workflows/e2e.yml`. This workflow automatically runs the integration tests on every pull request and push to the `main` branch. The tests require a valid `GEMINI_API_KEY` and the workflow skips execution when this variable is not available.
 
 The workflow runs the tests in different sandboxing environments to ensure Gemini CLI is tested across each:
 


### PR DESCRIPTION
## Summary
- skip e2e tests if the GEMINI_API_KEY secret isn't set
- document that the workflow skips e2e tests when the API key is missing

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685c8ee017d0832f816d496151f3acd5