### PR TITLE
Update docs with E2E_SKIP instructions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   e2e-test:
-    if: ${{ secrets.GEMINI_API_KEY != '' }}
+    if: ${{ secrets.GEMINI_API_KEY != '' && secrets.E2E_SKIP != 'true' }}
     name: E2E Test - ${{ matrix.sandbox }}
     runs-on: ubuntu-latest
     strategy:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ In the PR description, explain the "why" behind your changes and link to the rel
 
 ## Forking
 
-If you are forking the repository you will be able to run the Built, Test and Integration test workflows. However in order to make the integration tests run you'll need to add a [Github Repository Secret](<[url](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository)>) with a value of `GEMINI_API_KEY` and set that to a valid API key that you have available. Your key and secret it private to your repo; no one without access can see your key and you cannot see any secrets related to this repo.
+If you are forking the repository you will be able to run the Build, Test and Integration test workflows. However, in order to make the integration tests run you'll need to add a [GitHub Repository Secret](<[url](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository)>) with a value of `GEMINI_API_KEY` and set that to a valid API key that you have available. Your key and secret are private to your repo; no one without access can see your key and you cannot see any secrets related to this repo. If you do not want the integration tests to run, create a secret named `E2E_SKIP` with the value `true`. The workflow checks this secret and skips the E2E tests when it is set.
 
 Additionally you will need to click on the `Actions` tab and enable workflows for your repository, you'll find its the large blue button in the center of the screen.
 

--- a/docs/integration-tests.md
+++ b/docs/integration-tests.md
@@ -132,7 +132,7 @@ This structure makes it easy to locate the artifacts for a specific test run, fi
 
 ## Continuous integration
 
-To ensure the integration tests are always run, a GitHub Actions workflow is defined in `.github/workflows/e2e.yml`. This workflow automatically runs the integration tests on every pull request and push to the `main` branch. The tests require a valid `GEMINI_API_KEY` and the workflow skips execution when this variable is not available.
+To ensure the integration tests are always run, a GitHub Actions workflow is defined in `.github/workflows/e2e.yml`. This workflow automatically runs the integration tests on every pull request and push to the `main` branch. The tests require a valid `GEMINI_API_KEY` secret. If you do not want the tests to run (for example in a fork where you may not have an API key), create a repository secret named `E2E_SKIP` set to `true`. The workflow skips execution when `E2E_SKIP` is `true`.
 
 The workflow runs the tests in different sandboxing environments to ensure Gemini CLI is tested across each:
 


### PR DESCRIPTION
## Summary
- document how to skip running e2e workflow
- mention `E2E_SKIP` secret in contributing guide
- check `E2E_SKIP` in e2e workflow

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c92c735c4832fb2cb564af12ff938